### PR TITLE
Fix \u parsing to deal with negative values and fix failing test cases to conform to RTF spec 

### DIFF
--- a/lib/ruby-rtf/parser.rb
+++ b/lib/ruby-rtf/parser.rb
@@ -180,6 +180,10 @@ module RubyRTF
         if val == 32 || val == 8232
           add_modifier_section({:newline => true}, "\n")
         else
+          if val < 0
+            # RTF spec says that unicode codepoints > 32767 are expressed as negative numbers
+            val = val + 65536
+          end
           current_section[:text] << val.chr('utf-8')
         end
 

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -437,12 +437,12 @@ describe RubyRTF::Parser do
     it 'sets a unicode character < 1000 (char 643)' do
       parser.current_section[:text] = 'My code'
       parser.handle_control(:u, 643, nil, 0)
-      parser.current_section[:text].should == 'My codeك'
+      parser.current_section[:text].should == 'My codeʃ'
     end
 
-    it 'sets a unicode character < 32768 (char 2603)' do
+    it 'sets a unicode character < 32768 (char 9731)' do
       parser.current_section[:text] = 'My code'
-      parser.handle_control(:u, 2603, nil, 0)
+      parser.handle_control(:u, 9731, nil, 0)
       parser.current_section[:text].should == 'My code☃'
     end
 
@@ -459,12 +459,12 @@ describe RubyRTF::Parser do
       parser.current_section[:text].should == 'My code道'
     end
 
-    context "uc0 skips a byte in the next unicode char" do
+    context "uc0 skips 0 bytes in the next unicode char" do
       it "u8278" do
         parser.current_section[:text] = 'My code '
         parser.handle_control(:uc, 0, nil, 0)
         parser.handle_control(:u, 8278, nil, 0)
-        parser.current_section[:text].should == 'My code x'
+        parser.current_section[:text].should == 'My code ⁖'
       end
 
       it "u8232 - does newline" do


### PR DESCRIPTION
I think your unicode test cases are broken. See the email I sent you.
