### PR TITLE
remove unnecessarily specified dev dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,71 +6,7 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    Saikuro (1.1.0)
-    abstract (1.0.0)
-    activesupport (3.0.4)
-    arrayfields (4.7.4)
-    bluecloth (2.0.11)
-    chronic (0.2.3)
-      hoe (>= 1.2.1)
-    churn (0.0.13)
-      chronic (>= 0.2.3)
-      hirb
-      json_pure
-      main
-      ruby_parser (~> 2.0.4)
-      sexp_processor (~> 3.0.3)
-    colored (1.2)
     diff-lcs (1.1.2)
-    erubis (2.6.6)
-      abstract (>= 1.0.0)
-    fattr (2.2.0)
-    flay (1.4.2)
-      ruby_parser (~> 2.0)
-      sexp_processor (~> 3.0)
-    flog (2.5.1)
-      ruby_parser (~> 2.0)
-      sexp_processor (~> 3.0)
-    haml (3.0.25)
-    hirb (0.3.6)
-    hoe (2.9.1)
-      rake (>= 0.8.7)
-    i18n (0.5.0)
-    infinity_test (1.0.2)
-      notifiers (>= 1.1.0)
-      watchr (>= 0.7)
-    json_pure (1.5.1)
-    main (4.4.0)
-      arrayfields (>= 4.7.4)
-      fattr (>= 2.1.0)
-    metric_fu (2.0.1)
-      Saikuro (>= 1.1.0)
-      activesupport (>= 2.0.0)
-      chronic (~> 0.2.3)
-      churn (>= 0.0.7)
-      flay (>= 1.2.1)
-      flog (>= 2.2.0)
-      rails_best_practices (>= 0.3.16)
-      rcov (>= 0.8.3.3)
-      reek (>= 1.2.6)
-      roodi (>= 2.1.0)
-    notifiers (1.1.0)
-    rails_best_practices (0.7.0)
-      activesupport
-      colored (~> 1.2)
-      erubis (~> 2.6.6)
-      haml (~> 3.0.18)
-      i18n
-      ruby-progressbar (~> 0.0.9)
-      ruby_parser (~> 2.0.4)
-    rake (0.8.7)
-    rcov (0.9.9)
-    reek (1.2.8)
-      ruby2ruby (~> 1.2)
-      ruby_parser (~> 2.0)
-      sexp_processor (~> 3.0)
-    roodi (2.1.0)
-      ruby_parser
     rspec (2.5.0)
       rspec-core (~> 2.5.0)
       rspec-expectations (~> 2.5.0)
@@ -79,23 +15,13 @@ GEM
     rspec-expectations (2.5.0)
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.5.0)
-    ruby-progressbar (0.0.9)
-    ruby2ruby (1.2.5)
-      ruby_parser (~> 2.0)
-      sexp_processor (~> 3.0)
-    ruby_parser (2.0.6)
-      sexp_processor (~> 3.0)
-    sexp_processor (3.0.5)
-    watchr (0.7)
-    yard (0.6.4)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  bluecloth
-  infinity_test
-  metric_fu
   rspec (> 2.0)
   ruby-rtf!
-  yard
+
+BUNDLED WITH
+   1.14.6

--- a/ruby-rtf.gemspec
+++ b/ruby-rtf.gemspec
@@ -13,12 +13,7 @@ Gem::Specification.new do |s|
   s.summary = 'Library for working with RTF files'
   s.description = s.summary
 
-  s.add_development_dependency 'infinity_test'
   s.add_development_dependency 'rspec', '>2.0'
-  s.add_development_dependency 'metric_fu'
-
-  s.add_development_dependency 'yard'
-  s.add_development_dependency 'bluecloth'
 
   s.bindir = 'bin'
   s.executables << 'rtf_parse'


### PR DESCRIPTION
This might be a somewhat of a sticking point, but these specific
dependencies are purely preferential and not dependencies at all. Rspec
is a dependendy because the tests require it to run.

I also had trouble installing more than one of them.