### PR TITLE
Fix unknown encoding

### DIFF
--- a/lib/ruby-rtf/parser.rb
+++ b/lib/ruby-rtf/parser.rb
@@ -513,14 +513,20 @@ module RubyRTF
     def force_section!(mods = {}, text =  nil)
       current_context << @current_section
 
+      # The modifiers for the new section
+      modifiers = {}
+
       fs = formatting_stack.last || {}
       fs.each_pair do |k, v|
         next if BLACKLISTED.include?(k)
-        mods[k] = v
+        modifiers[k] = v
       end
-      formatting_stack.push(mods)
 
-      @current_section = {:text => (text || ''), :modifiers => mods}
+      modifiers.merge!(mods)
+
+      formatting_stack.push(modifiers)
+
+      @current_section = {:text => (text || ''), :modifiers => modifiers}
     end
 
     # Resets the current section to default formating

--- a/lib/ruby-rtf/parser.rb
+++ b/lib/ruby-rtf/parser.rb
@@ -126,7 +126,15 @@ module RubyRTF
       case(name)
       when :rtf then ;
       when :deff then @doc.default_font = val
-      when :ansicpg then self.encoding = "windows-#{val}"
+      when :ansicpg then
+        begin
+          # Set the encoding if it's valid
+          Encoding.find("windows-#{val}")
+          self.encoding = "windows-#{val}"
+        rescue => e
+          # ignore
+        end
+
       when *[:ansi, :mac, :pc, :pca] then @doc.character_set = name
       when :fonttbl then current_pos = parse_font_table(src, current_pos)
       when :colortbl then current_pos = parse_colour_table(src, current_pos)

--- a/lib/ruby-rtf/version.rb
+++ b/lib/ruby-rtf/version.rb
@@ -1,5 +1,5 @@
 # Main namespace of the RTF parser
 module RubyRTF
   # Current library version
-  VERSION = '0.0.4'
+  VERSION = '0.0.5'
 end


### PR DESCRIPTION
We were parsing some rtf files from users that were causing the "windows-10000" encoding to be set. This is not a valid Ruby encoding so the parsing was failing. With the code updates invalid encodings will be ignored.