### PR TITLE
Fix for spaces in colortbl section

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby-rtf (0.0.4)
+    ruby-rtf (0.0.5)
 
 GEM
   remote: http://rubygems.org/

--- a/lib/ruby-rtf/parser.rb
+++ b/lib/ruby-rtf/parser.rb
@@ -420,7 +420,7 @@ module RubyRTF
             colour.theme = ctrl.to_s[1..-1].to_sym
           end
 
-        when *["\r", "\n"] then current_pos += 1
+        when *["\r", "\n", " "] then current_pos += 1
         when ';' then
           @doc.colour_table << colour
 

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -391,6 +391,36 @@ ffd8ffe000104a4649460001010100b400b40000ffe1158a687474703a2f2f6e732e61646f62652e
       clr.blue.should == 255
     end
 
+    it 'ignores single space between colour sections' do
+      src = '{\rtf1{\colortbl\red0\green0\blue0; \red127\green2\blue255;}}'
+      doc = parser.parse(src)
+
+      clr = doc.colour_table[0]
+      clr.red.should == 0
+      clr.green.should == 0
+      clr.blue.should == 0
+
+      clr = doc.colour_table[1]
+      clr.red.should == 127
+      clr.green.should == 2
+      clr.blue.should == 255
+    end
+
+    it 'ignores double space between colour sections' do
+      src = '{\rtf1{\colortbl\red0\green0\blue0;  \red127\green2\blue255;}}'
+      doc = parser.parse(src)
+
+      clr = doc.colour_table[0]
+      clr.red.should == 0
+      clr.green.should == 0
+      clr.blue.should == 0
+
+      clr = doc.colour_table[1]
+      clr.red.should == 127
+      clr.green.should == 2
+      clr.blue.should == 255
+    end
+
     it 'sets the first colour if missing' do
       src = '{\rtf1{\colortbl;\red255\green0\blue0;\red0\green0\blue255;}}'
       doc = parser.parse(src)


### PR DESCRIPTION
We encountered an issue where a rogue space causes the parser to enter an infinite loop.