### PR TITLE
Fix font table size

### DIFF
--- a/lib/ruby-rtf/font.rb
+++ b/lib/ruby-rtf/font.rb
@@ -1,7 +1,7 @@
 module RubyRTF
   # Holds the information for a given font
   class Font
-    # @return [Integer] The font numberb
+    # @return [Integer] The font number
     attr_accessor :number
 
     # @return [String] The font name

--- a/lib/ruby-rtf/parser.rb
+++ b/lib/ruby-rtf/parser.rb
@@ -350,7 +350,7 @@ module RubyRTF
           font = RubyRTF::Font.new if font.nil?
 
           case(ctrl)
-          when :f then font.number = val
+          when :f then font.number = @doc.font_table.count
           when :fprq then font.pitch = val
           when :fcharset then font.character_set = val
           when *[:flomajor, :fhimajor, :fdbmajor, :fbimajor,


### PR DESCRIPTION
I've noticed that indices for table font entries are derived from sections, which produced font tables that could have hundreds of thousands of empty values. This PR changes that to build table font with indices in order.