### PR TITLE
Fix empty parse control value

### DIFF
--- a/lib/ruby-rtf/parser.rb
+++ b/lib/ruby-rtf/parser.rb
@@ -104,8 +104,8 @@ module RubyRTF
 
       contents = src[start, current_pos - start]
       m = contents.match(/([\*a-z]+)(\-?\d+)?\*?/)
-      ctrl = m[1].to_sym
-      val = m[2].to_i unless m[2].nil?
+      ctrl = m[1].to_sym unless m.nil? || m[1].nil?
+      val = m[2].to_i unless m.nil? || m[2].nil?
 
       # we advance past the optional space if present
       current_pos += 1 if src[current_pos] == ' '

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -172,6 +172,13 @@ ffd8ffe000104a4649460001010100b400b40000ffe1158a687474703a2f2f6e732e61646f62652e
       section[1][:modifiers].has_key?(:underline).should == false
       section[1][:text].should == 'World'
     end
+
+    it 'parses text when control matching fails' do
+      src = '{\rtf1 Hello\~{World}}'
+      section = parser.parse(src).sections
+      section[0][:text].should == 'Hello'
+      section[1][:text].should == 'World'
+    end
   end
 
   context '#parse_control' do
@@ -231,6 +238,10 @@ ffd8ffe000104a4649460001010100b400b40000ffe1158a687474703a2f2f6e732e61646f62652e
 
     it 'advances the current positon past the optional space' do
       parser.parse_control('Test ansi test', 5).last.should == 10
+    end
+
+    it 'does not fail when control matching fails' do
+      parser.parse_control('~}')[0, 2].should == ['', nil]
     end
   end
 


### PR DESCRIPTION
Some text combinations lead to 0 matches on this line, which causes the parser to fail with an error. The parser works perfectly if we just skip these matches and do not try to assign anything.